### PR TITLE
remove watched flag from meta item

### DIFF
--- a/src/main/proto/stremio/core/types/meta_item.proto
+++ b/src/main/proto/stremio/core/types/meta_item.proto
@@ -26,8 +26,7 @@ message MetaItem {
   required MetaItemBehaviorHints behavior_hints = 15;
   required MetaItemDeepLinks deep_links = 16;
   optional double progress = 17;
-  required bool watched = 18;
-  required bool in_library = 19;
+  required bool in_library = 18;
 }
 
 enum PosterShape {

--- a/src/main/rust/bridge/library_item.rs
+++ b/src/main/rust/bridge/library_item.rs
@@ -28,7 +28,7 @@ impl ToProtobuf<types::LibraryItem, ()> for LibraryItem {
             } else {
                 None
             },
-            watched: false, // TODO allow WatchedBitField construction just from string
+            watched: self.state.times_watched > 0
         }
     }
 }

--- a/src/main/rust/model/fields/meta_details.rs
+++ b/src/main/rust/model/fields/meta_details.rs
@@ -107,19 +107,6 @@ impl ToProtobuf<types::MetaItem, (Option<&MetaDetails>, Option<&String>, &Resour
                         None
                     }
                 }),
-            watched: details
-                .and_then(|details| details.watched.to_owned())
-                .map(|watched| {
-                    watched.get_video(
-                        &self
-                            .preview
-                            .behavior_hints
-                            .default_video_id
-                            .to_owned()
-                            .unwrap_or(self.preview.id.to_owned()),
-                    )
-                })
-                .unwrap_or_default(),
             in_library: details
                 .and_then(|details| details.library_item.to_owned())
                 .map(|item| !item.removed)


### PR DESCRIPTION
Movies are marked as watched in desktop app using property `timesWatched` and not the bitfield, so we cannot use it and it's better to remove it.

Mark lib item as watched:
https://github.com/Stremio/stremio/blob/a0f4c38eeec59e0a3b016800e2f5e1dbf257f6a5/src/pages/library/library.js#L117-L123

Is lib item watched:
https://github.com/Stremio/stremio/blob/a0f4c38eeec59e0a3b016800e2f5e1dbf257f6a5/src/pages/library/library.jade#L45