### PR TITLE
Propagate video_id for lib state and use ind items instead of MetaDetails

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1977,6 +1977,7 @@ dependencies = [
  "stremio-analytics",
  "stremio-core",
  "stremio-derive",
+ "stremio-watched-bitfield",
  "strum",
  "strum_macros",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ opt-level = 3
 stremio-core = { git = "https://github.com/Stremio/stremio-core", branch = "development", features = ["env-future-send"] }
 stremio-derive = { git = "https://github.com/Stremio/stremio-core", branch = "development" }
 stremio-analytics = { git = "https://github.com/Stremio/stremio-core", branch = "development" }
+stremio-watched-bitfield = { git = "https://github.com/Stremio/stremio-core", branch = "development" }
 serde = "1.0.*"
 serde_json = "1.0.*"
 futures = "0.3.*"

--- a/src/main/proto/stremio/core/types/library.proto
+++ b/src/main/proto/stremio/core/types/library.proto
@@ -22,4 +22,5 @@ message LibraryItem {
 message LibraryItemState {
   required uint64 time_offset = 1;
   required uint64 duration = 2;
+  optional string video_id = 3;
 }

--- a/src/main/rust/bridge/library_item.rs
+++ b/src/main/rust/bridge/library_item.rs
@@ -16,6 +16,7 @@ impl ToProtobuf<types::LibraryItem, ()> for LibraryItem {
             state: types::LibraryItemState {
                 time_offset: self.state.time_offset,
                 duration: self.state.duration,
+                video_id: self.state.video_id.clone(),
             },
             behavior_hints: self.behavior_hints.to_protobuf(&()),
             deep_links: types::MetaItemDeepLinks {

--- a/src/main/rust/bridge/loadable.rs
+++ b/src/main/rust/bridge/loadable.rs
@@ -1,12 +1,13 @@
 use stremio_core::models::common::{Loadable, ResourceError};
 use stremio_core::models::ctx::Ctx;
 use stremio_core::models::link::LinkError;
-use stremio_core::models::meta_details::MetaDetails;
 use stremio_core::models::streaming_server::Settings;
 use stremio_core::runtime::EnvError;
 use stremio_core::types::addon::ResourceRequest;
 use stremio_core::types::api::{LinkAuthKey, LinkCodeResponse};
+use stremio_core::types::library::LibraryItem;
 use stremio_core::types::resource::{MetaItem, MetaItemPreview, Stream, Subtitles};
+use stremio_watched_bitfield::WatchedBitField;
 use url::Url;
 
 use crate::bridge::ToProtobuf;
@@ -34,20 +35,26 @@ impl ToProtobuf<models::loadable_page::Content, (&Ctx, &ResourceRequest)>
 impl
     ToProtobuf<
         models::loadable_meta_item::Content,
-        (Option<&MetaDetails>, Option<&String>, &ResourceRequest),
+        (
+            Option<&LibraryItem>,
+            Option<&WatchedBitField>,
+            Option<&String>,
+            &ResourceRequest,
+        ),
     > for Loadable<MetaItem, ResourceError>
 {
     fn to_protobuf(
         &self,
-        (details, addon_name, meta_request): &(
-            Option<&MetaDetails>,
+        (library_item, watched, addon_name, meta_request): &(
+            Option<&LibraryItem>,
+            Option<&WatchedBitField>,
             Option<&String>,
             &ResourceRequest,
         ),
     ) -> models::loadable_meta_item::Content {
         match &self {
             Loadable::Ready(ready) => models::loadable_meta_item::Content::Ready(
-                ready.to_protobuf(&(*details, *addon_name, *meta_request)),
+                ready.to_protobuf(&(*library_item, *watched, *addon_name, *meta_request)),
             ),
             Loadable::Err(error) => models::loadable_meta_item::Content::Error(models::Error {
                 message: error.to_string(),

--- a/src/main/rust/model/fields/meta_details.rs
+++ b/src/main/rust/model/fields/meta_details.rs
@@ -5,7 +5,9 @@ use stremio_core::models::ctx::Ctx;
 use stremio_core::models::meta_details::{MetaDetails, Selected};
 use stremio_core::runtime::Env;
 use stremio_core::types::addon::ResourceRequest;
+use stremio_core::types::library::LibraryItem;
 use stremio_core::types::resource::{MetaItem, SeriesInfo, Video};
+use stremio_watched_bitfield::WatchedBitField;
 
 use crate::bridge::{FromProtobuf, ToProtobuf};
 use crate::env::AndroidEnv;
@@ -38,10 +40,23 @@ impl ToProtobuf<types::video::SeriesInfo, ()> for SeriesInfo {
     }
 }
 
-impl ToProtobuf<types::Video, (Option<&MetaDetails>, Option<&String>)> for Video {
+impl
+    ToProtobuf<
+        types::Video,
+        (
+            Option<&LibraryItem>,
+            Option<&WatchedBitField>,
+            Option<&String>,
+        ),
+    > for Video
+{
     fn to_protobuf(
         &self,
-        (details, addon_name): &(Option<&MetaDetails>, Option<&String>),
+        (library_item, watched, addon_name): &(
+            Option<&LibraryItem>,
+            Option<&WatchedBitField>,
+            Option<&String>,
+        ),
     ) -> types::Video {
         types::Video {
             id: self.id.to_string(),
@@ -55,26 +70,33 @@ impl ToProtobuf<types::Video, (Option<&MetaDetails>, Option<&String>)> for Video
                 .released
                 .map(|released| released > AndroidEnv::now())
                 .unwrap_or_default(),
-            watched: details
-                .and_then(|details| details.watched.to_owned())
+            watched: watched
                 .map(|watched| watched.get_video(&self.id))
                 .unwrap_or_default(),
-            current_video: details
-                .and_then(|details| details.library_item.to_owned())
-                .and_then(|library_item| library_item.state.video_id)
+            current_video: library_item
+                .and_then(|library_item| library_item.state.video_id.to_owned())
                 .map(|current_video_id| current_video_id == self.id)
                 .unwrap_or_default(),
         }
     }
 }
 
-impl ToProtobuf<types::MetaItem, (Option<&MetaDetails>, Option<&String>, &ResourceRequest)>
-    for MetaItem
+impl
+    ToProtobuf<
+        types::MetaItem,
+        (
+            Option<&LibraryItem>,
+            Option<&WatchedBitField>,
+            Option<&String>,
+            &ResourceRequest,
+        ),
+    > for MetaItem
 {
     fn to_protobuf(
         &self,
-        (details, addon_name, meta_request): &(
-            Option<&MetaDetails>,
+        (library_item, watched, addon_name, meta_request): &(
+            Option<&LibraryItem>,
+            Option<&WatchedBitField>,
             Option<&String>,
             &ResourceRequest,
         ),
@@ -96,22 +118,19 @@ impl ToProtobuf<types::MetaItem, (Option<&MetaDetails>, Option<&String>, &Resour
                 .preview
                 .trailer_streams
                 .to_protobuf(&(None, None, None)),
-            videos: self.videos.to_protobuf(&(*details, *addon_name)),
+            videos: self
+                .videos
+                .to_protobuf(&(*library_item, *watched, *addon_name)),
             behavior_hints: self.preview.behavior_hints.to_protobuf(&()),
             deep_links: MetaItemDeepLinks::from((self, *meta_request)).to_protobuf(&()),
-            progress: details
-                .and_then(|details| details.library_item.to_owned())
-                .and_then(|item| {
-                    if item.state.time_offset > 0 && item.state.duration > 0 {
-                        Some(item.state.time_offset as f64 / item.state.duration as f64)
-                    } else {
-                        None
-                    }
-                }),
-            in_library: details
-                .and_then(|details| details.library_item.to_owned())
-                .map(|item| !item.removed)
-                .unwrap_or_default(),
+            progress: library_item.and_then(|item| {
+                if item.state.time_offset > 0 && item.state.duration > 0 {
+                    Some(item.state.time_offset as f64 / item.state.duration as f64)
+                } else {
+                    None
+                }
+            }),
+            in_library: library_item.map(|item| !item.removed).unwrap_or_default(),
         }
     }
 }
@@ -169,7 +188,11 @@ impl ToProtobuf<models::MetaDetails, Ctx> for MetaDetails {
         models::MetaDetails {
             selected: self.selected.to_protobuf(&()),
             title,
-            meta_item: meta_item.to_protobuf(&(ctx, Some(self))),
+            meta_item: meta_item.to_protobuf(&(
+                ctx,
+                self.library_item.as_ref(),
+                self.watched.as_ref(),
+            )),
             streams: self.streams.to_protobuf(&(ctx, meta_request)),
         }
     }

--- a/src/main/rust/model/fields/player.rs
+++ b/src/main/rust/model/fields/player.rs
@@ -30,9 +30,15 @@ impl ToProtobuf<models::Player, Ctx> for Player {
     fn to_protobuf(&self, ctx: &Ctx) -> models::Player {
         models::Player {
             selected: self.selected.to_protobuf(&()),
-            meta_item: self.meta_item.as_ref().to_protobuf(&(ctx, None)),
+            meta_item: self.meta_item.as_ref().to_protobuf(&(
+                ctx,
+                self.library_item.as_ref(),
+                None,
+            )),
             subtitles: self.subtitles.to_protobuf(ctx),
-            next_video: self.next_video.to_protobuf(&(None, None)),
+            next_video: self
+                .next_video
+                .to_protobuf(&(self.library_item.as_ref(), None, None)),
             series_info: self.series_info.to_protobuf(&()),
             library_item: self.library_item.to_protobuf(&()),
         }


### PR DESCRIPTION
Add `video_id` to LibState
Use individual required items for building MetaItem and Video, instead of composed `MetaDetails` object, so that `Player` model could also have the extended properties.