### PR TITLE
Bump core

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,12 +34,6 @@ jobs:
         run: rustup target add i686-linux-android
       - name: Add x86_64 target
         run: rustup target add x86_64-linux-android
-      - name: Build code
-        run: cargo build --release
-      - name: Lint code format
-        run: cargo fmt --all -- --check
-      - name: Lint code
-        run: cargo clippy --all -- -D warnings
       - name: Build aar
         run: ./gradlew assembleRelease && ./gradlew assembleRelease
       - name: Upload build artifacts

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1944,7 +1944,7 @@ dependencies = [
 
 [[package]]
 name = "stremio-core-android"
-version = "1.0.14"
+version = "1.0.15"
 dependencies = [
  "auto_impl",
  "base64 0.13.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1896,7 +1896,7 @@ dependencies = [
 [[package]]
 name = "stremio-analytics"
 version = "0.1.0"
-source = "git+https://github.com/Stremio/stremio-core?branch=development#e26a4ffa309c59853f25a3ff867e60d969c5f063"
+source = "git+https://github.com/Stremio/stremio-core?branch=development#738d07ffd2e82a99f093bc81432eb6700665e898"
 dependencies = [
  "derivative",
  "enclose",
@@ -1909,7 +1909,7 @@ dependencies = [
 [[package]]
 name = "stremio-core"
 version = "0.1.0"
-source = "git+https://github.com/Stremio/stremio-core?branch=development#e26a4ffa309c59853f25a3ff867e60d969c5f063"
+source = "git+https://github.com/Stremio/stremio-core?branch=development#738d07ffd2e82a99f093bc81432eb6700665e898"
 dependencies = [
  "anyhow",
  "base64 0.13.0",
@@ -1987,7 +1987,7 @@ dependencies = [
 [[package]]
 name = "stremio-derive"
 version = "0.1.0"
-source = "git+https://github.com/Stremio/stremio-core?branch=development#e26a4ffa309c59853f25a3ff867e60d969c5f063"
+source = "git+https://github.com/Stremio/stremio-core?branch=development#738d07ffd2e82a99f093bc81432eb6700665e898"
 dependencies = [
  "case",
  "proc-macro-crate",
@@ -2006,7 +2006,7 @@ checksum = "f85866d77a26e83d3774dfcbb3871540b3e5e4fc753e26bdd5e8e4aa3bb9f9be"
 [[package]]
 name = "stremio-watched-bitfield"
 version = "0.1.0"
-source = "git+https://github.com/Stremio/stremio-core?branch=development#e26a4ffa309c59853f25a3ff867e60d969c5f063"
+source = "git+https://github.com/Stremio/stremio-core?branch=development#738d07ffd2e82a99f093bc81432eb6700665e898"
 dependencies = [
  "base64 0.13.0",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stremio-core-android"
-version = "1.0.14"
+version = "1.0.15"
 authors = ["Smart Code OOD"]
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ allprojects {
 
 ```gradle
 dependencies {
-    implementation 'com.github.Stremio:stremio-core-kotlin:1.0.14'
+    implementation 'com.github.Stremio:stremio-core-kotlin:1.0.15'
 }
 ```
 
 ## Manual
 
-[Download](https://jitpack.io/com/github/stremio/stremio-core-kotlin/1.0.14/stremio-core-kotlin-1.0.14.aar) aar and link
+[Download](https://jitpack.io/com/github/stremio/stremio-core-kotlin/1.0.15/stremio-core-kotlin-1.0.15.aar) aar and link
 it manually

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ android {
     }
 
     kotlinOptions {
-        freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
+        freeCompilerArgs += "-opt-in=kotlin.RequiresOptIn"
     }
 }
 
@@ -57,7 +57,7 @@ cargo {
 }
 
 dependencies {
-    implementation "androidx.core:core-ktx:1.7.0"
+    implementation "androidx.core:core-ktx:1.8.0"
     implementation "pro.streem.pbandk:pbandk-runtime:$pbandkVersion"
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -39,8 +39,8 @@ android {
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion 32
-        versionCode 15
-        versionName "1.0.14"
+        versionCode 16
+        versionName "1.0.15"
     }
 
     kotlinOptions {

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,4 +1,4 @@
 install:
   - wget https://github.com/Stremio/stremio-core-kotlin/releases/download/$VERSION/stremio-core-kotlin.aar
   - FILE="-Dfile=stremio-core-kotlin.aar"
-  - mvn install:install-file $FILE -DgroupId=com.stremio.core -DartifactId=stremio-core-kotlin -Dversion=1.0.14 -Dpackaging=aar -DgeneratePom=true
+  - mvn install:install-file $FILE -DgroupId=com.stremio.core -DartifactId=stremio-core-kotlin -Dversion=1.0.15 -Dpackaging=aar -DgeneratePom=true

--- a/pom.xml
+++ b/pom.xml
@@ -3,5 +3,5 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.stremio.core</groupId>
   <artifactId>stremio-core-kotlin</artifactId>
-  <version>1.0.14</version>
+  <version>1.0.15</version>
 </project>

--- a/src/main/proto/stremio/core/types/meta_item_preview.proto
+++ b/src/main/proto/stremio/core/types/meta_item_preview.proto
@@ -23,6 +23,7 @@ message MetaItemPreview {
   required MetaItemBehaviorHints behavior_hints = 15;
   required MetaItemDeepLinks deep_links = 16;
   required bool in_library = 17;
+  required bool in_cinema = 18;
 }
 
 message LinkPreview {

--- a/src/main/rust/bridge/meta_preview.rs
+++ b/src/main/rust/bridge/meta_preview.rs
@@ -1,9 +1,12 @@
+use chrono::Duration;
 use stremio_core::deep_links::MetaItemDeepLinks;
 use stremio_core::models::ctx::Ctx;
+use stremio_core::runtime::Env;
 use stremio_core::types::addon::ResourceRequest;
 use stremio_core::types::resource::{MetaItemBehaviorHints, MetaItemPreview, PosterShape};
 
 use crate::bridge::{FromProtobuf, ToProtobuf};
+use crate::env::AndroidEnv;
 use crate::protobuf::stremio::core::types;
 
 impl FromProtobuf<MetaItemBehaviorHints> for types::MetaItemBehaviorHints {
@@ -85,6 +88,11 @@ impl ToProtobuf<types::MetaItemPreview, (&Ctx, &ResourceRequest)> for MetaItemPr
                 .items
                 .get(&self.id)
                 .map(|library_item| !library_item.removed)
+                .unwrap_or_default(),
+            in_cinema: self
+                .released
+                .filter(|_released| self.r#type == "movie")
+                .map(|released| released + Duration::days(30) > AndroidEnv::now())
                 .unwrap_or_default(),
         }
     }


### PR DESCRIPTION
Also remove linting step from `release` pipeline to make it faster, since it's already done in the build pipeline, so no need to duplicate it.