### PR TITLE
Merge `jni` lib folder after `cargo build`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Add x86_64 target
         run: rustup target add x86_64-linux-android
       - name: Build aar
-        run: ./gradlew assembleRelease && ./gradlew assembleRelease
+        run: ./gradlew assembleRelease
       - name: Upload build artifacts
         uses: svenstaro/upload-release-action@v2
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -84,7 +84,7 @@ protobuf {
 }
 
 tasks.whenTaskAdded { task ->
-    if (task.name == "javaPreCompileDebug" || task.name == "javaPreCompileRelease") {
+    if (task.name == "javaPreCompileDebug" || task.name == "javaPreCompileRelease" || task.name == 'mergeDebugJniLibFolders' || task.name == 'mergeReleaseJniLibFolders') {
         task.dependsOn "cargoBuild"
     }
 }


### PR DESCRIPTION
This fixes an issue where the `jni` folder is only included in the resulting `.aar`  file after a second `./gradlew assembleRelease` build.