### PR TITLE
fix: patch openssl & reflink

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Android SDK
         uses: android-actions/setup-android@v2
       - name: Setup Android NDK
-        run: yes | sdkmanager "ndk;21.0.6113669" >/dev/null
+        run: yes | sdkmanager "ndk;25.2.9519653"" >/dev/null
 
       - uses: dtolnay/rust-toolchain@stable
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1214,8 +1214,7 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 [[package]]
 name = "openssl-src"
 version = "111.27.0+1.1.1v"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06e8f197c82d7511c5b014030c9b1efeda40d7d5f99d23b4ceed3524a5e63f02"
+source = "git+https://github.com/sleeyax/openssl-src-rs?rev=920c4df6b10dbca574810c0dc88db4bca4c332af#920c4df6b10dbca574810c0dc88db4bca4c332af"
 dependencies = [
  "cc",
 ]
@@ -1421,8 +1420,7 @@ dependencies = [
 [[package]]
 name = "reflink"
 version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc585ec28b565b4c28977ce8363a6636cedc280351ba25a7915f6c9f37f68cbe"
+source = "git+https://github.com/nicokoch/reflink?rev=e8d93b46#e8d93b465f5d9ad340cd052b64bbc77b8ee107e2"
 dependencies = [
  "libc",
  "winapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ glob = "0.3.0"
 # see https://github.com/nicokoch/reflink/issues/4
 reflink = { git = "https://github.com/nicokoch/reflink", rev = "e8d93b46" }
 # see https://github.com/alexcrichton/openssl-src-rs/issues/188
-openssl-src = { git = "https://github.com/sleeyax/openssl-src-rs", rev =  "920c4df6b10dbca574810c0dc88db4bca4c332af" }
+openssl-src = { git = "https://github.com/Stremio/openssl-src-rs", rev =  "920c4df6b10dbca574810c0dc88db4bca4c332af" }
 
 # [patch.'https://github.com/Stremio/stremio-core']
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,12 @@ prost-build = "0.11"
 protox = "0.4"
 glob = "0.3.0"
 
+[patch.crates-io]
+# see https://github.com/nicokoch/reflink/issues/4
+reflink = { git = "https://github.com/nicokoch/reflink", rev = "e8d93b46" }
+# see https://github.com/alexcrichton/openssl-src-rs/issues/188
+openssl-src = { git = "https://github.com/sleeyax/openssl-src-rs", rev =  "920c4df6b10dbca574810c0dc88db4bca4c332af" }
+
 # [patch.'https://github.com/Stremio/stremio-core']
 
 # stremio-core = { path = "../core" }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,7 +69,7 @@ kotlin {
 
 android {
     compileSdk = 33
-    ndkVersion = "21.0.6113669"
+    ndkVersion = "25.2.9519653"
 
     defaultConfig {
         minSdk = 21


### PR DESCRIPTION
Without this change, the mentioned crates don't compile. OpenSSL has an issue with finding the RANLIB and AR binaries on the system and reflink has compilation errors in its source (this issue is fixed on GitHub but no update has been published to crate.io).

Also upgraded from NDK version `21.0.6113669` to `25.2.9519653`.