### PR TITLE
Fix LibraryItem deep links

### DIFF
--- a/src/commonMain/rust/bridge/deep_links.rs
+++ b/src/commonMain/rust/bridge/deep_links.rs
@@ -1,6 +1,6 @@
-use stremio_core::deep_links::{LibraryItemDeepLinks, ExternalPlayerLink};
 use crate::bridge::ToProtobuf;
 use crate::protobuf::stremio::core::types;
+use stremio_core::deep_links::{ExternalPlayerLink, LibraryItemDeepLinks};
 
 impl ToProtobuf<types::LibraryItemDeepLinks, ()> for LibraryItemDeepLinks {
     fn to_protobuf(&self, _args: &()) -> types::LibraryItemDeepLinks {

--- a/src/commonMain/rust/bridge/deep_links.rs
+++ b/src/commonMain/rust/bridge/deep_links.rs
@@ -1,0 +1,23 @@
+use stremio_core::deep_links::{LibraryItemDeepLinks, ExternalPlayerLink};
+use crate::bridge::ToProtobuf;
+use crate::protobuf::stremio::core::types;
+
+impl ToProtobuf<types::LibraryItemDeepLinks, ()> for LibraryItemDeepLinks {
+    fn to_protobuf(&self, _args: &()) -> types::LibraryItemDeepLinks {
+        types::LibraryItemDeepLinks {
+            meta_details_videos: self.meta_details_videos.to_owned(),
+            meta_details_streams: self.meta_details_streams.to_owned(),
+            player: self.player.to_owned(),
+            external_player: self.external_player.to_protobuf(&()),
+        }
+    }
+}
+
+impl ToProtobuf<types::ExternalPlayerLink, ()> for ExternalPlayerLink {
+    fn to_protobuf(&self, _args: &()) -> types::ExternalPlayerLink {
+        types::ExternalPlayerLink {
+            download: self.download.to_owned(),
+            streaming: self.streaming.to_owned(),
+        }
+    }
+}

--- a/src/commonMain/rust/bridge/library_item.rs
+++ b/src/commonMain/rust/bridge/library_item.rs
@@ -35,11 +35,7 @@ impl ToProtobuf<types::LibraryItem, (&Ctx, Option<usize>)> for LibraryItem {
                 no_notif: self.state.no_notif,
             },
             behavior_hints: self.behavior_hints.to_protobuf(&()),
-            deep_links: types::MetaItemDeepLinks {
-                meta_details_videos: deep_links.meta_details_videos,
-                meta_details_streams: deep_links.meta_details_streams,
-                player: deep_links.player,
-            },
+            deep_links: deep_links.to_protobuf(&()),
             progress: self.progress(),
             watched: self.state.times_watched > 0,
             notifications: notifications as u64,

--- a/src/commonMain/rust/bridge/mod.rs
+++ b/src/commonMain/rust/bridge/mod.rs
@@ -10,6 +10,9 @@ pub use auth_request::*;
 mod date;
 pub use date::*;
 
+mod deep_links;
+pub use deep_links::*;
+
 mod env_error;
 pub use env_error::*;
 

--- a/src/commonMain/rust/bridge/stream.rs
+++ b/src/commonMain/rust/bridge/stream.rs
@@ -205,7 +205,7 @@ impl
             },
             deep_links: types::StreamDeepLinks {
                 player: deep_links.player,
-                external_player: types::stream_deep_links::ExternalPlayerLink {
+                external_player: types::ExternalPlayerLink {
                     download: deep_links.external_player.download,
                     streaming: deep_links.external_player.streaming,
                 },

--- a/src/main/proto/stremio/core/models/streaming_server.proto
+++ b/src/main/proto/stremio/core/models/streaming_server.proto
@@ -6,6 +6,7 @@ option java_package = "com.stremio.core.models";
 
 import "stremio/core/models/loadable.proto";
 import "stremio/core/types/meta_item.proto";
+import "stremio/core/types/deep_links.proto";
 
 message StreamingServer {
   required Selected selected = 1;

--- a/src/main/proto/stremio/core/types/deep_links.proto
+++ b/src/main/proto/stremio/core/types/deep_links.proto
@@ -1,0 +1,28 @@
+syntax = "proto2";
+
+package stremio.core.types;
+
+option java_package = "com.stremio.core.types.resource";
+
+message MetaItemDeepLinks {
+    optional string meta_details_videos = 1;
+    optional string meta_details_streams = 2;
+    optional string player = 3;
+}
+
+message LibraryItemDeepLinks {
+    optional string meta_details_videos = 1;
+    optional string meta_details_streams = 2;
+    optional string player = 3;
+    optional ExternalPlayerLink external_player = 4;
+}
+
+message StreamDeepLinks {
+    required string player = 1;
+    required ExternalPlayerLink external_player = 2;
+}
+
+message ExternalPlayerLink {
+    optional string download = 1;
+    optional string streaming = 2;
+}

--- a/src/main/proto/stremio/core/types/library.proto
+++ b/src/main/proto/stremio/core/types/library.proto
@@ -5,6 +5,7 @@ package stremio.core.types;
 option java_package = "com.stremio.core.types.library";
 
 import "stremio/core/types/meta_item.proto";
+import "stremio/core/types/deep_links.proto";
 
 message LibraryItem {
   required string id = 1;
@@ -14,7 +15,7 @@ message LibraryItem {
   required PosterShape poster_shape = 5;
   required LibraryItemState state = 6;
   required MetaItemBehaviorHints behavior_hints = 7;
-  required MetaItemDeepLinks deep_links = 8;
+  required LibraryItemDeepLinks deep_links = 8;
   required double progress = 9;
   required bool watched = 10;
   required uint64 notifications = 11;

--- a/src/main/proto/stremio/core/types/meta_item.proto
+++ b/src/main/proto/stremio/core/types/meta_item.proto
@@ -7,6 +7,7 @@ option java_package = "com.stremio.core.types.resource";
 import "google/protobuf/timestamp.proto";
 import "stremio/core/types/stream.proto";
 import "stremio/core/types/video.proto";
+import "stremio/core/types/deep_links.proto";
 
 message MetaItem {
   required string id = 1;
@@ -46,10 +47,4 @@ message MetaItemBehaviorHints {
   optional string default_video_id = 1;
   optional string featured_video_id = 2;
   required bool has_scheduled_videos = 3;
-}
-
-message MetaItemDeepLinks {
-  optional string meta_details_videos = 1;
-  optional string meta_details_streams = 2;
-  optional string player = 3;
 }

--- a/src/main/proto/stremio/core/types/meta_item_preview.proto
+++ b/src/main/proto/stremio/core/types/meta_item_preview.proto
@@ -6,6 +6,7 @@ option java_package = "com.stremio.core.types.resource";
 
 import "google/protobuf/timestamp.proto";
 import "stremio/core/types/meta_item.proto";
+import "stremio/core/types/deep_links.proto";
 
 message MetaItemPreview {
   required string id = 1;

--- a/src/main/proto/stremio/core/types/stream.proto
+++ b/src/main/proto/stremio/core/types/stream.proto
@@ -5,6 +5,7 @@ package stremio.core.types;
 option java_package = "com.stremio.core.types.resource";
 
 import "stremio/core/types/subtitle.proto";
+import "stremio/core/types/deep_links.proto";
 
 message Stream {
   oneof source {
@@ -73,14 +74,4 @@ message StreamBehaviorHints {
 message StreamProxyHeaders {
   map<string, string> request = 1;
   map<string, string> response = 2;
-}
-
-message StreamDeepLinks {
-  required string player = 1;
-  required ExternalPlayerLink external_player = 2;
-
-  message ExternalPlayerLink {
-    optional string download = 1;
-    optional string streaming = 2;
-  }
 }


### PR DESCRIPTION
LibraryItem was using MetaItemDeepLinks instead of LibraryItemDeepLinks
Moved the deeplinks to a designated file  