### PR TITLE
Feat/StreamItemState subtitles size and offset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2396,7 +2396,7 @@ dependencies = [
 [[package]]
 name = "stremio-core"
 version = "0.1.0"
-source = "git+https://github.com/Stremio/stremio-core?branch=development#70684d03151e17eb05c2ea55caf13d69bc6eb586"
+source = "git+https://github.com/Stremio/stremio-core?branch=development#645d6ec6d5be197c05fceecda45ba78a8f3b59b2"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -2500,7 +2500,7 @@ dependencies = [
 [[package]]
 name = "stremio-derive"
 version = "0.1.0"
-source = "git+https://github.com/Stremio/stremio-core?branch=development#70684d03151e17eb05c2ea55caf13d69bc6eb586"
+source = "git+https://github.com/Stremio/stremio-core?branch=development#645d6ec6d5be197c05fceecda45ba78a8f3b59b2"
 dependencies = [
  "case",
  "proc-macro-crate",
@@ -2534,7 +2534,7 @@ dependencies = [
 [[package]]
 name = "stremio-watched-bitfield"
 version = "0.1.0"
-source = "git+https://github.com/Stremio/stremio-core?branch=development#70684d03151e17eb05c2ea55caf13d69bc6eb586"
+source = "git+https://github.com/Stremio/stremio-core?branch=development#645d6ec6d5be197c05fceecda45ba78a8f3b59b2"
 dependencies = [
  "base64 0.13.1",
  "flate2",

--- a/stremio-core-protobuf/proto/stremio/core/models/player.proto
+++ b/stremio-core-protobuf/proto/stremio/core/models/player.proto
@@ -31,10 +31,12 @@ message Player {
   message StreamState {
     optional SubtitleTrack subtitle_track = 1;
     optional int64 subtitle_delay = 2;
-    optional AudioTrack audio_track = 3;
-    optional int64 audio_delay = 4;
-    optional float playback_speed = 5;
-    optional string player_type = 6;
+    optional int64 subtitle_size = 3;
+    optional int64 subtitle_offset = 4;
+    optional AudioTrack audio_track = 5;
+    optional int64 audio_delay = 6;
+    optional float playback_speed = 7;
+    optional string player_type = 8;
   }
   message SubtitleTrack {
     required string id = 1;

--- a/stremio-core-protobuf/src/bridge.rs
+++ b/stremio-core-protobuf/src/bridge.rs
@@ -21,6 +21,7 @@ mod meta_preview;
 mod option;
 mod pair;
 mod poster_shape;
+mod primitives;
 mod profile;
 mod resource_loadable;
 mod resource_path;
@@ -29,7 +30,7 @@ mod stream;
 mod string;
 mod subtitle;
 
-pub trait ToProtobuf<T, A> {
+pub trait ToProtobuf<T, A = ()> {
     fn to_protobuf<E: Env + 'static>(&self, args: &A) -> T;
 }
 

--- a/stremio-core-protobuf/src/bridge/primitives.rs
+++ b/stremio-core-protobuf/src/bridge/primitives.rs
@@ -1,0 +1,15 @@
+use stremio_core::runtime::Env;
+
+use super::{FromProtobuf, ToProtobuf};
+
+impl ToProtobuf<i64> for u64 {
+    fn to_protobuf<E: Env + 'static>(&self, _args: &()) -> i64 {
+        i64::try_from(*self).unwrap_or_default()
+    }
+}
+
+impl FromProtobuf<u64> for i64 {
+    fn from_protobuf(&self) -> u64 {
+        u64::try_from(*self).unwrap_or_default()
+    }
+}

--- a/stremio-core-protobuf/src/model/fields/player.rs
+++ b/stremio-core-protobuf/src/model/fields/player.rs
@@ -21,6 +21,8 @@ impl FromProtobuf<StreamItemState> for models::player::StreamState {
         StreamItemState {
             subtitle_track: self.subtitle_track.from_protobuf(),
             subtitle_delay: self.subtitle_delay.to_owned(),
+            subtitle_size: self.subtitle_size.from_protobuf(),
+            subtitle_offset: self.subtitle_offset.from_protobuf(),
             audio_track: self.audio_track.from_protobuf(),
             audio_delay: self.audio_delay.to_owned(),
             playback_speed: self.playback_speed.to_owned(),
@@ -79,6 +81,8 @@ impl ToProtobuf<models::player::StreamState, ()> for StreamItemState {
         models::player::StreamState {
             subtitle_track: self.subtitle_track.to_protobuf::<E>(&()),
             subtitle_delay: self.subtitle_delay.to_owned(),
+            subtitle_size: self.subtitle_size.to_protobuf::<E>(&()),
+            subtitle_offset: self.subtitle_offset.to_protobuf::<E>(&()),
             audio_track: self.audio_track.to_protobuf::<E>(&()),
             audio_delay: self.audio_delay.to_owned(),
             playback_speed: self.playback_speed.to_owned(),


### PR DESCRIPTION
adds implementation for u64 To/FromProtobuf i64 type.

**IMPORTANT:** https://play.rust-lang.org/?version=stable&mode=release&edition=2021&gist=8e015632caca4bec05afaeeb590fc907

having e.g. u64 > i64::MAX and conversion with `as i64` and `i64 < 0`with `as u64` will cause issues in conversion.
This is why I've added an impl that uses `TryFrom` for both types and if an under/overflow happens in the conversion (aka an Error is returned) then we use `0` as value.

Related core PR: https://github.com/Stremio/stremio-core/pull/735

# TODOs
- [ ] Once merged, replace other places where we use `as u64` or `as i64` in the conversion, e.g. in `VideoParams`