### PR TITLE
fix: map subtitle label field in protobuf bridge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2299,7 +2299,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "stremio-core"
 version = "0.1.0"
-source = "git+https://github.com/Stremio/stremio-core?branch=development#9a827fdd6f319ba3c22a96436c5f61292cb24ff1"
+source = "git+https://github.com/Stremio/stremio-core?branch=development#b5d3833f031f183b55b4db89d90a28e2fdd3d0fc"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2410,7 +2410,7 @@ dependencies = [
 [[package]]
 name = "stremio-derive"
 version = "0.1.0"
-source = "git+https://github.com/Stremio/stremio-core?branch=development#9a827fdd6f319ba3c22a96436c5f61292cb24ff1"
+source = "git+https://github.com/Stremio/stremio-core?branch=development#b5d3833f031f183b55b4db89d90a28e2fdd3d0fc"
 dependencies = [
  "case",
  "proc-macro-crate",
@@ -2440,7 +2440,7 @@ dependencies = [
 [[package]]
 name = "stremio-watched-bitfield"
 version = "0.1.0"
-source = "git+https://github.com/Stremio/stremio-core?branch=development#9a827fdd6f319ba3c22a96436c5f61292cb24ff1"
+source = "git+https://github.com/Stremio/stremio-core?branch=development#b5d3833f031f183b55b4db89d90a28e2fdd3d0fc"
 dependencies = [
  "base64 0.13.1",
  "flate2",

--- a/stremio-core-protobuf/proto/stremio/core/types/subtitle.proto
+++ b/stremio-core-protobuf/proto/stremio/core/types/subtitle.proto
@@ -9,4 +9,5 @@ message Subtitle {
   required string lang = 2;
   required string url = 3;
   optional string name = 4;
+  optional string label = 5;
 }

--- a/stremio-core-protobuf/src/bridge/subtitle.rs
+++ b/stremio-core-protobuf/src/bridge/subtitle.rs
@@ -9,6 +9,7 @@ impl FromProtobuf<Subtitles> for types::Subtitle {
             id: self.id.clone(),
             lang: self.lang.to_string(),
             url: self.url.from_protobuf(),
+            label: self.label.clone(),
         }
     }
 }
@@ -23,6 +24,7 @@ impl ToProtobuf<types::Subtitle, Option<&String>> for Subtitles {
             lang: self.lang.to_string(),
             url: self.url.to_string(),
             name: addon_name.cloned(),
+            label: self.label.clone(),
         }
     }
 }


### PR DESCRIPTION
Closes #109

## Problem

[stremio-core#947](https://github.com/Stremio/stremio-core/pull/947) (v0.55.0) added a `label: Option<String>` field to the `Subtitles` struct, allowing addons to provide custom display names for subtitle tracks. However, the protobuf bridge doesn't map this field, so Android/Android TV apps never receive it.

Currently, the protobuf `name` field (field 4) is populated with the **addon name** via `addon_name.cloned()`, not the subtitle's own label.

## Changes

1. **subtitle.proto**: Added `optional string label = 5` to the `Subtitle` message
2. **subtitle.rs**: Map `Subtitles.label` to the new protobuf `label` field in both `ToProtobuf` and `FromProtobuf`
3. **Cargo.lock**: Updated stremio-core dependency from `9a827fdd` to `b5d3833f` to pick up the `label` field on the `Subtitles` struct

The existing `name` field (field 4) is left unchanged - it continues to carry the addon name. The new `label` field (field 5) is additive and backward compatible.

## Related

- [stremio-core#947](https://github.com/Stremio/stremio-core/pull/947) - Added `label` to `Subtitles` type
- [stremio-web#1166](https://github.com/Stremio/stremio-web/issues/1166) - Companion fix for web client
- [stremio-bugs#544](https://github.com/AntaresApp/stremio-bugs/issues/544) - Android TV subtitle name issues

## Android app follow-up

Once this bridge change is merged, the Android app's subtitle picker would need to prefer `label` over the resolved `lang` name for variant display. Since the app is closed source, this would be handled by the Stremio team.